### PR TITLE
🪲 Some fixes for hardware

### DIFF
--- a/miner.cpp
+++ b/miner.cpp
@@ -17,6 +17,7 @@
 #include <mutex>
 #include <functional>
 #include <sstream>
+#include <algorithm>
 
 #include "utils/keccak.h"
 #include "utils/misc.h"


### PR DESCRIPTION
This might just be my older hardware talking, but I got this error on make:[^hrd]

```bash
g++ -O3 -DNDEBUG -ffast-math -funroll-loops -fopenmp -pthread -std=c++17 -Iutils -march=native -flto -DGPU=0 -c miner.cpp -o miner.o
miner.cpp: In function ‘int main(int, char**)’:
miner.cpp:232:36: error: ‘remove_if’ is not a member of ‘std’; did you mean ‘remove_cv’?
  232 |                 threads.erase(std::remove_if(threads.begin(), threads.end(),
      |                                    ^~~~~~~~~
      |                                    remove_cv
make: *** [Makefile:37: miner.o] Error 1
```

It was simple enough to fix with the added import committed.

[^hrd]: I'm running on linux with an old i7 and 1070/1060 non-SLI. Unfortunately, it's giving me an execution error, too: `GPU support not enabled in this build`